### PR TITLE
Reorganized CMake files for a proper modular build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,5 @@
 .vscode/
+
+# Ignore CMake artifacts
+build/
+install/

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "test/Unity"]
+	path = test/Unity
+	url = https://github.com/ThrowTheSwitch/Unity.git

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,13 @@
+# Top-level CMakeLists.txt
+cmake_minimum_required(VERSION 3.5)
+
+project(c_data_structures_and_algorithms)
+
+# Implementations
+add_subdirectory(src/circular_buffer)
+
+# Test Framework
+add_subdirectory(test/Unity)
+
+# Tests
+add_subdirectory(test/circular_buffer)

--- a/src/circular_buffer/CMakeLists.txt
+++ b/src/circular_buffer/CMakeLists.txt
@@ -1,0 +1,21 @@
+# Header files
+set(HEADERS
+    include/circular_buffer.h
+)
+
+# Source files
+set(SOURCES 
+    circular_buffer.c
+)
+
+# Create a public library for the implementation
+add_library(circular_buffer ${HEADERS} ${SOURCES})
+
+# add the include directory to the overall project for visibility
+target_include_directories(circular_buffer PUBLIC
+    include
+)
+
+# Specify installation instructions for the lib and header files
+install(TARGETS circular_buffer DESTINATION lib)
+install(FILES ${HEADERS} DESTINATION include/circular_buffer)

--- a/src/control_flow/control_flow.c
+++ b/src/control_flow/control_flow.c
@@ -1,0 +1,42 @@
+#include <stdlib.h>
+#include <stdio.h>
+#include <assert.h>
+#include <limits.h>
+
+int absolute_value(int a) {
+    // INT_MIN cannot be negated without signed overflow
+    assert(a != INT_MIN);
+    if (a < 0) {
+        return -a;
+    }
+    return a;
+}
+
+size_t find_element(size_t len, int* arr, int key) {
+    size_t pos = -1;
+
+    for (size_t i = 0; i < len; i++) {
+        if (arr[i] == key) {
+            pos = i;
+            break;
+        }
+    }
+
+    return pos;
+}
+
+int main(void) {
+    size_t length = 8;
+    int arr[] = {7, 12, -2, 999, 0, 13, 4, 99};
+    printf("Array: ");
+    for (int i = 0; i < 8; i++) {
+        printf("%d ", arr[i]);
+    }
+    printf("\n");
+
+    printf("Position of 12: %ld\n", find_element(length, arr, 12));
+    printf("Position of 80: %ld\n", find_element(length, arr, 80));
+
+    printf("Absolute value of -10: %d\n", absolute_value(-10));
+    printf("Absolute value of INT_MIN: %d\n", absolute_value(INT_MIN));
+}

--- a/test/circular_buffer/CMakeLists.txt
+++ b/test/circular_buffer/CMakeLists.txt
@@ -1,30 +1,15 @@
-cmake_minimum_required(VERSION 3.5)
-
-project(circular_buffer_tests)
-
-# Unity is a library that we have to include
-# Unity has some sources we need to add to the executable
-
-# src/circular_buffer is a library?, whatever it is, we need to include it
-# src/circular_buffer/include is an "include directory" that has some header files we need
-# src/circular_buffer has some source files we need to add to the executable
-
-# List all the .c source files that need to be compiled for the test suite to run
+# List all the source files that make up the test suite
 set(CIRC_BUF_SOURCES
-    test_circular_buffer.c
-    ../../src/circular_buffer/circular_buffer.c
-    ../../../Unity/src/unity.c   
+    test_circular_buffer.c  
 )
 
-# Create an executable target for make based on all the source files
+# Create an executable target based on all the source files
 add_executable(circular_buffer_basic_test ${CIRC_BUF_SOURCES})
 
-# specify the directories where to look for all the included header files 
-target_include_directories(circular_buffer_basic_test PRIVATE 
-    ../../src/circular_buffer 
-    ../../src/circular_buffer/include 
-    ../../../Unity/src
+# Link the unit test framework and the circbuf implementation as libraries
+target_link_libraries(circular_buffer_basic_test
+    unity
+    circular_buffer
 )
 
-# TODO: clean this up to not have to use relative paths for every single source file and header
-# TODO: investigate library concept for adding the non-test files (unity files, circbuf files)
+install(TARGETS circular_buffer_basic_test DESTINATION bin/tests)


### PR DESCRIPTION
## Changes
- Reorganized CMake files into a top-level CMakeLists that describes the overall project, and sub-directory CMakeLists that represents each discrete "project component"
- Created a CMake "library" out of the circular_buffer implementation files
- Added Unity framework as a git submodule into the repo so that CMake can treat it as a "library"
- Created a CMake "executable" out of the circular_buffer unit test suite
- Linked the Unity framework and circular_buffer implementations as static libraries for the unit test suite
- Added book exercises from Ch5 (control_flow)